### PR TITLE
Feature/cs/soc 702 try callback pattern

### DIFF
--- a/chris-callback/.gitignore
+++ b/chris-callback/.gitignore
@@ -1,0 +1,20 @@
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Serverless directories
+.serverless

--- a/chris-callback/handler.py
+++ b/chris-callback/handler.py
@@ -14,15 +14,17 @@ def start_task_and_wait_for_callback(event, context):
 
         print(f'Calling Step Functions to complete callback with {params}')
         # output is the JSON output of the task as a str
-        res = sfn.send_task_success(taskToken=task_token, output=
+        res = sfn.send_task_success(taskToken=task_token,
+                                    output=json.dumps({'msg': 'WHATEVER'}))
         print(f'sendTaskSuccess res={res}')
         # send_task_failure(taskToken=..., error='...', cause='...')
 
-def notify_success(event, context):
-    print(f'success: event={event}')
-    return {'msg': 'Looking Good'}
+
+# def notify_success(event, context):
+#     print(f'success: event={event}')
+#     return {'msg': 'Looking Good'}
 
 
-def notify_failure(event, context):
-    print(f'failure: event={event}')
-    return {'msg': 'Failure Dude'}
+# def notify_failure(event, context):
+#     print(f'failure: event={event}')
+#     return {'msg': 'Failure Dude'}

--- a/chris-callback/handler.py
+++ b/chris-callback/handler.py
@@ -11,7 +11,8 @@ def start_task_and_wait_for_callback(event, context):
     # Here we would do something useful, then continue the statemachine
     print(f'sending success...')
     res = sfn.send_task_success(taskToken=task_token,
-                                output=json.dumps({'msg': 'WHATEVER DUDE'}))
+                                output=json.dumps({'msg': 'WHATEVER DUDE',
+                                                   'taskToken': task_token}))
     print(f'sendTaskSuccess res={res}')
     # send_task_failure(taskToken=..., error='...', cause='...')
     return {'msg': 'does this really get sent anywhere?'}

--- a/chris-callback/handler.py
+++ b/chris-callback/handler.py
@@ -12,31 +12,27 @@ def start_task_and_wait_for_callback(event, context):
     # Here we would do something useful, then continue the statemachine
     # with success or failure depending on outcome of that work;
     # for now, just randomly pick one.
-    # TODO: create a Lambda exception and see how SNF detects it
     chance = random()
-    print(f'chance={chance}')
-    if chance > 0.75:
-        print(f'sending success...')
+    if chance > 0.80:
         res = sfn.send_task_success(taskToken=task_token,
                                     output=json.dumps({'msg': 'WHATEVER DUDE',
                                                        'chance': chance,
                                                        'token': task_token}))
-        print(f'sendTaskSuccess res={res}')
-    elif chance > 0.50:
-        print(f'sending failure: error and cause go to next step input')
+    elif chance > 0.60:
         res = sfn.send_task_failure(taskToken=task_token,
                                     error='UnluckyError',
                                     cause=f'You were unlucky {chance}')
-        print(f'sendTaskFailure res={res}')
-    elif chance > 0.25:
-        print(f'sending failure: error and cause go to next step input')
+    elif chance > 0.40:
         res = sfn.send_task_failure(taskToken=task_token,
                                     error='SadPath',
                                     cause=f'Not the happy path {chance}')
-        print(f'sendTaskFailure res={res}')
+    elif chance > 0.20:
+        res = sfn.send_task_failure(taskToken=task_token,
+                                    error='CannotRecover',
+                                    cause=f'We coud not recover {chance}')
     else:
         raise RuntimeError(f'Simulated unhandled logic error {chance}')
-    return {'msg': 'This does not get sent anywhere!'}
+    # return {'msg': 'This does not get sent anywhere!'}
 
 
 def happy_path(event, context):

--- a/chris-callback/handler.py
+++ b/chris-callback/handler.py
@@ -1,4 +1,5 @@
 import json
+from random import random
 
 import boto3
 
@@ -9,19 +10,39 @@ def start_task_and_wait_for_callback(event, context):
     task_token = event['taskToken']
     print(f'task_token={task_token}')
     # Here we would do something useful, then continue the statemachine
-    print(f'sending success...')
-    res = sfn.send_task_success(taskToken=task_token,
-                                output=json.dumps({'msg': 'WHATEVER DUDE',
-                                                   'taskToken': task_token}))
-    print(f'sendTaskSuccess res={res}')
-    # send_task_failure(taskToken=..., error='...', cause='...')
-    return {'msg': 'does this really get sent anywhere?'}
+    # with success or failure depending on outcome of that work;
+    # for now, just randomly pick one.
+    # TODO: create a Lambda exception and see how SNF detects it
+    chance = random()
+    print(f'chance={chance}')
+    if chance > 0.66:
+        print(f'sending success...')
+        res = sfn.send_task_success(taskToken=task_token,
+                                    output=json.dumps({'msg': 'WHATEVER DUDE',
+                                                       'chance': chance,
+                                                       'taskToken': task_token}))
+        print(f'sendTaskSuccess res={res}')
+    elif chance > 0.33:
+        print(f'sending failure: error and cause go to next step input')
+        res = sfn.send_task_failure(taskToken=task_token,
+                                    error='UnluckyError',
+                                    cause=f'You were unlucky, chance={chance}')
+        print(f'sendTaskFailure res={res}')
+    else:
+        raise RuntimeError(f'Simulated unhandled logic error chance={chance}')
+    return {'msg': 'This does not get sent anywhere!'}
+
 
 def notify_success(event, context):
     print(f'success: event={event}')
     return {'msg': 'Looking Good'}
 
 
-# def notify_failure(event, context):
-#     print(f'failure: event={event}')
-#     return {'msg': 'Failure Dude'}
+def notify_unlucky(event, contect):
+    print(f'unluck error: event={event}')
+    return {'msg': f'Your state machine was unlucky today event={event}'}
+
+
+# def notify_task_failed(event, context):
+#     print(f'task failed: event={event}')
+#     return {'msg': 'Task Failed, can we get Python traceback?'}

--- a/chris-callback/handler.py
+++ b/chris-callback/handler.py
@@ -17,9 +17,9 @@ def start_task_and_wait_for_callback(event, context):
     # send_task_failure(taskToken=..., error='...', cause='...')
     return {'msg': 'does this really get sent anywhere?'}
 
-# def notify_success(event, context):
-#     print(f'success: event={event}')
-#     return {'msg': 'Looking Good'}
+def notify_success(event, context):
+    print(f'success: event={event}')
+    return {'msg': 'Looking Good'}
 
 
 # def notify_failure(event, context):

--- a/chris-callback/handler.py
+++ b/chris-callback/handler.py
@@ -6,19 +6,15 @@ import boto3
 def start_task_and_wait_for_callback(event, context):
     print(f'startwait: event={event}')
     sfn = boto3.client('stepfunctions')
-    for record in event['Records']:
-        message_body = json.loads(record['body'])
-        task_token = message_body['TaskToken']
-        params = {'output': 'Callback task completed successfully',
-                  'taskToken': task_token}
-
-        print(f'Calling Step Functions to complete callback with {params}')
-        # output is the JSON output of the task as a str
-        res = sfn.send_task_success(taskToken=task_token,
-                                    output=json.dumps({'msg': 'WHATEVER'}))
-        print(f'sendTaskSuccess res={res}')
-        # send_task_failure(taskToken=..., error='...', cause='...')
-
+    task_token = event['taskToken']
+    print(f'task_token={task_token}')
+    # Here we would do something useful, then continue the statemachine
+    print(f'sending success...')
+    res = sfn.send_task_success(taskToken=task_token,
+                                output=json.dumps({'msg': 'WHATEVER DUDE'}))
+    print(f'sendTaskSuccess res={res}')
+    # send_task_failure(taskToken=..., error='...', cause='...')
+    return {'msg': 'does this really get sent anywhere?'}
 
 # def notify_success(event, context):
 #     print(f'success: event={event}')

--- a/chris-callback/handler.py
+++ b/chris-callback/handler.py
@@ -20,35 +20,35 @@ def start_task_and_wait_for_callback(event, context):
         res = sfn.send_task_success(taskToken=task_token,
                                     output=json.dumps({'msg': 'WHATEVER DUDE',
                                                        'chance': chance,
-                                                       'taskToken': task_token}))
+                                                       'token': task_token}))
         print(f'sendTaskSuccess res={res}')
     elif chance > 0.50:
         print(f'sending failure: error and cause go to next step input')
         res = sfn.send_task_failure(taskToken=task_token,
                                     error='UnluckyError',
-                                    cause=f'You were unlucky, chance={chance}')
+                                    cause=f'You were unlucky {chance}')
         print(f'sendTaskFailure res={res}')
     elif chance > 0.25:
         print(f'sending failure: error and cause go to next step input')
         res = sfn.send_task_failure(taskToken=task_token,
                                     error='SadPath',
-                                    cause=f'This is not the happy path, chance={chance}')
+                                    cause=f'Not the happy path {chance}')
         print(f'sendTaskFailure res={res}')
     else:
-        raise RuntimeError(f'Simulated unhandled logic error chance={chance}')
+        raise RuntimeError(f'Simulated unhandled logic error {chance}')
     return {'msg': 'This does not get sent anywhere!'}
 
 
-def notify_success(event, context):
-    print(f'success: event={event}')
+def happy_path(event, context):
+    print(f'happy_path: event={event}')
     return {'msg': 'Looking Good'}
 
 
-def notify_unlucky(event, contect):
-    print(f'unlucky: event={event}')
-    return {'msg': f'Your state machine was unlucky today event={event}'}
-
-
-def notify_sad_path(event, contect):
+def sad_path(event, contect):
     print(f'sad_path: event={event}')
     return {'msg': f'Sorry, this was not the happy path event={event}'}
+
+
+def unlucky(event, contect):
+    print(f'unlucky: event={event}')
+    return {'msg': f'Your state machine was unlucky today event={event}'}

--- a/chris-callback/handler.py
+++ b/chris-callback/handler.py
@@ -1,0 +1,28 @@
+import json
+
+import boto3
+
+
+def start_task_and_wait_for_callback(event, context):
+    print(f'startwait: event={event}')
+    sfn = boto3.client('stepfunctions')
+    for record in event['Records']:
+        message_body = json.loads(record['body'])
+        task_token = message_body['TaskToken']
+        params = {'output': 'Callback task completed successfully',
+                  'taskToken': task_token}
+
+        print(f'Calling Step Functions to complete callback with {params}')
+        # output is the JSON output of the task as a str
+        res = sfn.send_task_success(taskToken=task_token, output=
+        print(f'sendTaskSuccess res={res}')
+        # send_task_failure(taskToken=..., error='...', cause='...')
+
+def notify_success(event, context):
+    print(f'success: event={event}')
+    return {'msg': 'Looking Good'}
+
+
+def notify_failure(event, context):
+    print(f'failure: event={event}')
+    return {'msg': 'Failure Dude'}

--- a/chris-callback/handler.py
+++ b/chris-callback/handler.py
@@ -15,18 +15,24 @@ def start_task_and_wait_for_callback(event, context):
     # TODO: create a Lambda exception and see how SNF detects it
     chance = random()
     print(f'chance={chance}')
-    if chance > 0.66:
+    if chance > 0.75:
         print(f'sending success...')
         res = sfn.send_task_success(taskToken=task_token,
                                     output=json.dumps({'msg': 'WHATEVER DUDE',
                                                        'chance': chance,
                                                        'taskToken': task_token}))
         print(f'sendTaskSuccess res={res}')
-    elif chance > 0.33:
+    elif chance > 0.50:
         print(f'sending failure: error and cause go to next step input')
         res = sfn.send_task_failure(taskToken=task_token,
                                     error='UnluckyError',
                                     cause=f'You were unlucky, chance={chance}')
+        print(f'sendTaskFailure res={res}')
+    elif chance > 0.25:
+        print(f'sending failure: error and cause go to next step input')
+        res = sfn.send_task_failure(taskToken=task_token,
+                                    error='SadPath',
+                                    cause=f'This is not the happy path, chance={chance}')
         print(f'sendTaskFailure res={res}')
     else:
         raise RuntimeError(f'Simulated unhandled logic error chance={chance}')
@@ -39,10 +45,10 @@ def notify_success(event, context):
 
 
 def notify_unlucky(event, contect):
-    print(f'unluck error: event={event}')
+    print(f'unlucky: event={event}')
     return {'msg': f'Your state machine was unlucky today event={event}'}
 
 
-# def notify_task_failed(event, context):
-#     print(f'task failed: event={event}')
-#     return {'msg': 'Task Failed, can we get Python traceback?'}
+def notify_sad_path(event, contect):
+    print(f'sad_path: event={event}')
+    return {'msg': f'Sorry, this was not the happy path event={event}'}

--- a/chris-callback/serverless.yml
+++ b/chris-callback/serverless.yml
@@ -11,23 +11,13 @@ provider:
   region: us-east-1
   logRetentionInDays: 14
   iamRoleStatements:
-    # Allow the lamba(s) to trigger the statemachine.
-    # This seems to be applying to Lambda but not some STS thing?
-    # (AccessDeniedException) when calling the SendTaskSuccess operation: User: 
-    # arn:aws:sts::304932368623:assumed-role/chriscallback-dev-us-east-1-lambdaRole/chriscallback-dev-StartTaskAndWaitForCallback
-    # is not authorized to perform: states:SendTaskSuccess
-    # on resource: arn:aws:states:us-east-1:304932368623:stateMachine:ChrisCallbackStepFunctionsStateMachine-Esf4lC8jq7c9",
     - Effect: Allow
       Action:
       - states:SendTaskFailure
       - states:SendTaskSuccess
-      #- states:GetActivityTask
-      #- states:SendTaskHeartbeat # what is this for?
       Resource: 
       - "arn:aws:states:#{AWS::Region}:#{AWS::AccountId}:states:SendTaskSuccess"
       - Ref: ChrisCallbackStepFunctionsStateMachine
-
-
 
 stepFunctions:
   stateMachines:
@@ -40,8 +30,6 @@ stepFunctions:
         StartAt: StartTaskAndWaitForCallback
         States:
           StartTaskAndWaitForCallback:
-            # Do something like sleep for 4 secs, issue a success or failure code
-            # NOTE: no Next here to get to Success so the Lambda must be running.
             Type: Task
             Resource: arn:aws:states:::lambda:invoke.waitForTaskToken
             Parameters:
@@ -49,28 +37,28 @@ stepFunctions:
               Payload:
                 yo: Mama
                 taskToken.$: $$.Task.Token
-            Next: NotifySuccess
+            Next: HappyPath
             Catch:
             # Put our named failures before generic TaskFailed
             - ErrorEquals: ["UnluckyError"]
-              Next: NotifyUnlucky
+              Next: Unlucky
             - ErrorEquals: ["SadPath"]
-              Next: NotifySadPath
+              Next: SadPath
             - ErrorEquals: ["States.TaskFailed"]
-              Next: NotifyTaskFailed
-          NotifySuccess:
+              Next: TaskFailed
+          HappyPath:
             Type: Task
-            Resource: "arn:aws:lambda:#{AWS::Region}:#{AWS::AccountId}:function:${self:service}-${opt:stage}-NotifySuccess"
+            Resource: "arn:aws:lambda:#{AWS::Region}:#{AWS::AccountId}:function:${self:service}-${opt:stage}-HappyPath"
             End: true
-          NotifyUnlucky:
+          SadPath:
             Type: Task
-            Resource: "arn:aws:lambda:#{AWS::Region}:#{AWS::AccountId}:function:${self:service}-${opt:stage}-NotifyUnlucky"
+            Resource: "arn:aws:lambda:#{AWS::Region}:#{AWS::AccountId}:function:${self:service}-${opt:stage}-SadPath"
             End: true           # treated as success, but could Next to a Fail state
-          NotifySadPath:
+          Unlucky:
             Type: Task
-            Resource: "arn:aws:lambda:#{AWS::Region}:#{AWS::AccountId}:function:${self:service}-${opt:stage}-NotifySadPath"
+            Resource: "arn:aws:lambda:#{AWS::Region}:#{AWS::AccountId}:function:${self:service}-${opt:stage}-Unlucky"
             End: true           # treated as success, but could Next to a Fail state
-          NotifyTaskFailed:
+          TaskFailed:
             # Cause and Error are optional
             Type: Fail
             Error: You have an unhandled error in your code
@@ -79,9 +67,9 @@ stepFunctions:
 functions:
   StartTaskAndWaitForCallback:
     handler: handler.start_task_and_wait_for_callback
-  NotifySuccess:
-    handler: handler.notify_success
-  NotifyUnlucky:
-    handler: handler.notify_unlucky
-  NotifySadPath:
-    handler: handler.notify_sad_path
+  HappyPath:
+    handler: handler.happy_path
+  Unlucky:
+    handler: handler.unlucky
+  SadPath:
+    handler: handler.sad_path

--- a/chris-callback/serverless.yml
+++ b/chris-callback/serverless.yml
@@ -1,0 +1,39 @@
+service: chriscallback
+#app: your-app-name
+#tenant: your-tenant-name
+
+provider:
+  name: aws
+  runtime: python3.7
+
+  stage: dev
+  region: us-east-1
+
+stepFunctions:
+  stateMachines:
+    ChrisCallback:
+      definition:
+        StartAt: StartTaskAndWaitForCallback
+        States:
+          StartTaskAndWaitForCallback:
+            # Should sleep for 4 seconds then issue a success or failure code
+            Type: Task
+            Resource: "arn:aws:lambda:#{AWS::Region}:#{AWS::AccountId}:function:${self:service}-${opt:stage}-WaitForCallback"
+            input:
+              TaskToken.$: $$.Task.Token
+          NotifySuccess:
+            Type: Task
+            Resource: "arn:aws:lambda:#{AWS::Region}:#{AWS::AccountId}:function:${self:service}-${opt:stage}-NotifySuccess"
+            End: true
+          NotifyFailure:
+            Type: Task
+            Resource: "arn:aws:lambda:#{AWS::Region}:#{AWS::AccountId}:function:${self:service}-${opt:stage}-NotifyFailure"
+            End: true
+
+functions:
+  StartTaskAndWaitForCallback:
+    handler: handler.start_task_and_wait_for_callback
+  NotifySuccess:
+    handler: handler.notify_success
+  NotifyFailure:
+    handler: handler.notify_failure

--- a/chris-callback/serverless.yml
+++ b/chris-callback/serverless.yml
@@ -25,11 +25,8 @@ provider:
       #- states:SendTaskHeartbeat # what is this for?
       Resource: 
       - "arn:aws:states:#{AWS::Region}:#{AWS::AccountId}:states:SendTaskSuccess"
-      - "arn:aws:states:#{AWS::Region}:#{AWS::AccountId}:stateMachine:ChrisCallbackStepFunctionsStateMachine-Esf4lC8jq7c9"
-      #- "*"                     # DANGER DANGER DANGER: tighten this to just the STS? 
-      #Ref: WaitForOcrStepFunctionsActivity   #Can I do someting like this?
-      #Resource: "arn:aws:states:#{AWS::Region}:#{AWS::AccountId}:activity:WaitForOcr"
-      #  Fn::GetAtt: [WaitForUploadStepFunctionsActivity, Arn]
+      - Ref: ChrisCallbackStepFunctionsStateMachine
+
 
 
 stepFunctions:

--- a/chris-callback/serverless.yml
+++ b/chris-callback/serverless.yml
@@ -5,9 +5,13 @@ service: chriscallback
 provider:
   name: aws
   runtime: python3.7
-
   stage: dev
   region: us-east-1
+  logRetentionInDays: 14
+
+plugins:
+  - serverless-pseudo-parameters
+  - serverless-step-functions
 
 stepFunctions:
   stateMachines:
@@ -16,19 +20,26 @@ stepFunctions:
         StartAt: StartTaskAndWaitForCallback
         States:
           StartTaskAndWaitForCallback:
-            # Should sleep for 4 seconds then issue a success or failure code
+            # Do something like sleep for 4 secs, issue a success or failure code
+            # NOTE: no Next here to get to Success so the Lambda must be running.
+            # BUG: this didn't create a step function
             Type: Task
-            Resource: "arn:aws:lambda:#{AWS::Region}:#{AWS::AccountId}:function:${self:service}-${opt:stage}-WaitForCallback"
-            input:
-              TaskToken.$: $$.Task.Token
+            #Function not found:
+            #          arn:aws:lambda:us-east-1:304932368623:function:chriscallback-dev-WaitForCallback 
+            # Console  arn:aws:lambda:us-east-1:304932368623:function:chriscallback-dev-StartTaskAndWaitForCallback
+            Resource: "arn:aws:lambda:#{AWS::Region}:#{AWS::AccountId}:function:${self:service}-${opt:stage}-StartTaskAndWaitForCallback"
+            Next: NotifySuccess
+            # Invalid
+            # input:
+            #   TaskToken.$: $$.Task.Token
           NotifySuccess:
             Type: Task
             Resource: "arn:aws:lambda:#{AWS::Region}:#{AWS::AccountId}:function:${self:service}-${opt:stage}-NotifySuccess"
             End: true
-          NotifyFailure:
-            Type: Task
-            Resource: "arn:aws:lambda:#{AWS::Region}:#{AWS::AccountId}:function:${self:service}-${opt:stage}-NotifyFailure"
-            End: true
+          # NotifyFailure:
+          #   Type: Task
+          #   Resource: "arn:aws:lambda:#{AWS::Region}:#{AWS::AccountId}:function:${self:service}-${opt:stage}-NotifyFailure"
+          #   End: true
 
 functions:
   StartTaskAndWaitForCallback:

--- a/chris-callback/serverless.yml
+++ b/chris-callback/serverless.yml
@@ -25,10 +25,9 @@ provider:
       #- states:SendTaskHeartbeat # what is this for?
       Resource: 
       - "arn:aws:states:#{AWS::Region}:#{AWS::AccountId}:states:SendTaskSuccess"
-      - "*"                     # DANGER DANGER DANGER: tighten this to just the STS? 
-
+      - "arn:aws:states:#{AWS::Region}:#{AWS::AccountId}:stateMachine:ChrisCallbackStepFunctionsStateMachine-Esf4lC8jq7c9"
+      #- "*"                     # DANGER DANGER DANGER: tighten this to just the STS? 
       #Ref: WaitForOcrStepFunctionsActivity   #Can I do someting like this?
-
       #Resource: "arn:aws:states:#{AWS::Region}:#{AWS::AccountId}:activity:WaitForOcr"
       #  Fn::GetAtt: [WaitForUploadStepFunctionsActivity, Arn]
 

--- a/chris-callback/serverless.yml
+++ b/chris-callback/serverless.yml
@@ -49,15 +49,15 @@ stepFunctions:
               Payload:
                 yo: Mama
                 taskToken.$: $$.Task.Token
-            #Next: NotifySuccess
-            End: true
+            Next: NotifySuccess
+            #End: true
             # Invalid
             # input:
             #   TaskToken.$: $$.Task.Token
-          # NotifySuccess:
-          #   Type: Task
-          #   Resource: "arn:aws:lambda:#{AWS::Region}:#{AWS::AccountId}:function:${self:service}-${opt:stage}-NotifySuccess"
-          #   End: true
+          NotifySuccess:
+            Type: Task
+            Resource: "arn:aws:lambda:#{AWS::Region}:#{AWS::AccountId}:function:${self:service}-${opt:stage}-NotifySuccess"
+            End: true
           # NotifyFailure:
           #   Type: Task
           #   Resource: "arn:aws:lambda:#{AWS::Region}:#{AWS::AccountId}:function:${self:service}-${opt:stage}-NotifyFailure"

--- a/chris-callback/serverless.yml
+++ b/chris-callback/serverless.yml
@@ -51,8 +51,11 @@ stepFunctions:
                 taskToken.$: $$.Task.Token
             Next: NotifySuccess
             Catch:
-            - ErrorEquals: ["UnluckyError"] # this has to be before TaskFailed?
+            # Put our named failures before generic TaskFailed
+            - ErrorEquals: ["UnluckyError"]
               Next: NotifyUnlucky
+            - ErrorEquals: ["SadPath"]
+              Next: NotifySadPath
             - ErrorEquals: ["States.TaskFailed"]
               Next: NotifyTaskFailed
           NotifySuccess:
@@ -62,12 +65,16 @@ stepFunctions:
           NotifyUnlucky:
             Type: Task
             Resource: "arn:aws:lambda:#{AWS::Region}:#{AWS::AccountId}:function:${self:service}-${opt:stage}-NotifyUnlucky"
-            End: true           # but still seen as success
+            End: true           # treated as success, but could Next to a Fail state
+          NotifySadPath:
+            Type: Task
+            Resource: "arn:aws:lambda:#{AWS::Region}:#{AWS::AccountId}:function:${self:service}-${opt:stage}-NotifySadPath"
+            End: true           # treated as success, but could Next to a Fail state
           NotifyTaskFailed:
+            # Cause and Error are optional
             Type: Fail
-            Cause: Unhandled error in code
-            #Resource: "arn:aws:lambda:#{AWS::Region}:#{AWS::AccountId}:function:${self:service}-${opt:stage}-NotifyTaskFailed"
-            #End: 
+            Error: You have an unhandled error in your code
+            Cause: check the input to this state for the traceback
 
 functions:
   StartTaskAndWaitForCallback:
@@ -76,3 +83,5 @@ functions:
     handler: handler.notify_success
   NotifyUnlucky:
     handler: handler.notify_unlucky
+  NotifySadPath:
+    handler: handler.notify_sad_path

--- a/chris-callback/serverless.yml
+++ b/chris-callback/serverless.yml
@@ -32,6 +32,10 @@ provider:
 stepFunctions:
   stateMachines:
     ChrisCallback:
+      events:
+        - http:
+            path: start
+            method: GET
       definition:
         StartAt: StartTaskAndWaitForCallback
         States:

--- a/chris-callback/serverless.yml
+++ b/chris-callback/serverless.yml
@@ -44,6 +44,8 @@ stepFunctions:
               Next: Unlucky
             - ErrorEquals: ["SadPath"]
               Next: SadPath
+            - ErrorEquals: ["CannotRecover"]
+              Next: CannotRecover
             - ErrorEquals: ["States.TaskFailed"]
               Next: TaskFailed
           HappyPath:
@@ -58,8 +60,12 @@ stepFunctions:
             Type: Task
             Resource: "arn:aws:lambda:#{AWS::Region}:#{AWS::AccountId}:function:${self:service}-${opt:stage}-Unlucky"
             End: true           # treated as success, but could Next to a Fail state
+          # For type FAIL, Error and Cause are optional
+          CannotRecover:
+            Type: Fail
+            Error: Sorry we could not recover from some problem
+            Cause: check the input to this state for the traceback
           TaskFailed:
-            # Cause and Error are optional
             Type: Fail
             Error: You have an unhandled error in your code
             Cause: check the input to this state for the traceback

--- a/chris-callback/serverless.yml
+++ b/chris-callback/serverless.yml
@@ -1,6 +1,8 @@
 service: chriscallback
-#app: your-app-name
-#tenant: your-tenant-name
+
+plugins:
+  - serverless-pseudo-parameters
+  - serverless-step-functions
 
 provider:
   name: aws
@@ -8,10 +10,28 @@ provider:
   stage: dev
   region: us-east-1
   logRetentionInDays: 14
+  iamRoleStatements:
+    # Allow the lamba(s) to trigger the statemachine.
+    # This seems to be applying to Lambda but not some STS thing?
+    # (AccessDeniedException) when calling the SendTaskSuccess operation: User: 
+    # arn:aws:sts::304932368623:assumed-role/chriscallback-dev-us-east-1-lambdaRole/chriscallback-dev-StartTaskAndWaitForCallback
+    # is not authorized to perform: states:SendTaskSuccess
+    # on resource: arn:aws:states:us-east-1:304932368623:stateMachine:ChrisCallbackStepFunctionsStateMachine-Esf4lC8jq7c9",
+    - Effect: Allow
+      Action:
+      - states:SendTaskFailure
+      - states:SendTaskSuccess
+      #- states:GetActivityTask
+      #- states:SendTaskHeartbeat # what is this for?
+      Resource: 
+      - "arn:aws:states:#{AWS::Region}:#{AWS::AccountId}:states:SendTaskSuccess"
+      - "*"                     # DANGER DANGER DANGER: tighten this to just the STS? 
 
-plugins:
-  - serverless-pseudo-parameters
-  - serverless-step-functions
+      #Ref: WaitForOcrStepFunctionsActivity   #Can I do someting like this?
+
+      #Resource: "arn:aws:states:#{AWS::Region}:#{AWS::AccountId}:activity:WaitForOcr"
+      #  Fn::GetAtt: [WaitForUploadStepFunctionsActivity, Arn]
+
 
 stepFunctions:
   stateMachines:
@@ -22,20 +42,22 @@ stepFunctions:
           StartTaskAndWaitForCallback:
             # Do something like sleep for 4 secs, issue a success or failure code
             # NOTE: no Next here to get to Success so the Lambda must be running.
-            # BUG: this didn't create a step function
             Type: Task
-            #Function not found:
-            #          arn:aws:lambda:us-east-1:304932368623:function:chriscallback-dev-WaitForCallback 
-            # Console  arn:aws:lambda:us-east-1:304932368623:function:chriscallback-dev-StartTaskAndWaitForCallback
-            Resource: "arn:aws:lambda:#{AWS::Region}:#{AWS::AccountId}:function:${self:service}-${opt:stage}-StartTaskAndWaitForCallback"
-            Next: NotifySuccess
+            Resource: arn:aws:states:::lambda:invoke.waitForTaskToken
+            Parameters:
+              FunctionName: ${self:service}-${opt:stage}-StartTaskAndWaitForCallback
+              Payload:
+                yo: Mama
+                taskToken.$: $$.Task.Token
+            #Next: NotifySuccess
+            End: true
             # Invalid
             # input:
             #   TaskToken.$: $$.Task.Token
-          NotifySuccess:
-            Type: Task
-            Resource: "arn:aws:lambda:#{AWS::Region}:#{AWS::AccountId}:function:${self:service}-${opt:stage}-NotifySuccess"
-            End: true
+          # NotifySuccess:
+          #   Type: Task
+          #   Resource: "arn:aws:lambda:#{AWS::Region}:#{AWS::AccountId}:function:${self:service}-${opt:stage}-NotifySuccess"
+          #   End: true
           # NotifyFailure:
           #   Type: Task
           #   Resource: "arn:aws:lambda:#{AWS::Region}:#{AWS::AccountId}:function:${self:service}-${opt:stage}-NotifyFailure"

--- a/chris-callback/serverless.yml
+++ b/chris-callback/serverless.yml
@@ -50,23 +50,29 @@ stepFunctions:
                 yo: Mama
                 taskToken.$: $$.Task.Token
             Next: NotifySuccess
-            #End: true
-            # Invalid
-            # input:
-            #   TaskToken.$: $$.Task.Token
+            Catch:
+            - ErrorEquals: ["UnluckyError"] # this has to be before TaskFailed?
+              Next: NotifyUnlucky
+            - ErrorEquals: ["States.TaskFailed"]
+              Next: NotifyTaskFailed
           NotifySuccess:
             Type: Task
             Resource: "arn:aws:lambda:#{AWS::Region}:#{AWS::AccountId}:function:${self:service}-${opt:stage}-NotifySuccess"
             End: true
-          # NotifyFailure:
-          #   Type: Task
-          #   Resource: "arn:aws:lambda:#{AWS::Region}:#{AWS::AccountId}:function:${self:service}-${opt:stage}-NotifyFailure"
-          #   End: true
+          NotifyUnlucky:
+            Type: Task
+            Resource: "arn:aws:lambda:#{AWS::Region}:#{AWS::AccountId}:function:${self:service}-${opt:stage}-NotifyUnlucky"
+            End: true           # but still seen as success
+          NotifyTaskFailed:
+            Type: Fail
+            Cause: Unhandled error in code
+            #Resource: "arn:aws:lambda:#{AWS::Region}:#{AWS::AccountId}:function:${self:service}-${opt:stage}-NotifyTaskFailed"
+            #End: 
 
 functions:
   StartTaskAndWaitForCallback:
     handler: handler.start_task_and_wait_for_callback
   NotifySuccess:
     handler: handler.notify_success
-  NotifyFailure:
-    handler: handler.notify_failure
+  NotifyUnlucky:
+    handler: handler.notify_unlucky


### PR DESCRIPTION
@vanhongts I've gotten the "callback" pattern to work.
In this example, I have success being "HappyPath".
I have two send_task_failure which trigger different states which are then treated as success.
And I've got a send_task_failure which ends in a state treated as failure.
Finally, a state that catches python logic errors, which I trigger. 

The documentation on this, even in the reference manual, was pretty bad, so I think this is good example code.
I'll demo it today.